### PR TITLE
Configure CD for terraform-aws-ci-cd

### DIFF
--- a/.github/workflows/terraform-CD.yml
+++ b/.github/workflows/terraform-CD.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 env:
-  ROLE_ARN: "arn:aws:iam::493370826424:role/ih-tf-terraform-aws-cloud-init-github"
+  ROLE_ARN: "arn:aws:iam::493370826424:role/ih-tf-terraform-aws-ci-cd-github"
   AWS_DEFAULT_REGION: "us-west-1"
 
 jobs:


### PR DESCRIPTION
Publish the module to https://registry.infrahouse.com on a tag push